### PR TITLE
Remove redundant room ID label from header

### DIFF
--- a/client/src/components/Header.css
+++ b/client/src/components/Header.css
@@ -22,12 +22,6 @@
   gap: 0.75rem;
 }
 
-.room-id {
-  color: var(--color-text-muted);
-  font-size: 0.875rem;
-  font-family: monospace;
-}
-
 .copy-btn {
   padding: 0.375rem 0.75rem;
   font-size: 0.8rem;

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -15,7 +15,6 @@ export default function Header({ roomId }) {
     <header className="header">
       <h1 className="header-title">Story Pointer</h1>
       <div className="header-room">
-        <span className="room-id">Room: {roomId}</span>
         <button className="copy-btn" onClick={copyLink}>
           {copied ? 'Copied!' : 'Copy Link'}
         </button>


### PR DESCRIPTION
## Summary

- Removes the `Room: {roomId}` span from the header — the room ID is already embedded in the URL the "Copy Link" button copies
- Deletes the now-dead `.room-id` CSS rule

Closes #1

## Test plan

- [x] Open a room — confirm no room ID text appears in the header
- [x] Click "Copy Link" — confirm the copied URL contains the correct room ID
- [x] `npm test` passes
- [x] `npm run lint && npm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)