### PR TITLE
Fix GitHub Deployment status showing cancelled after Railway deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,6 @@ jobs:
         run: npm install -g @railway/cli
 
       - name: Deploy
-        run: railway up --detach --service server
+        run: railway up --service server
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}


### PR DESCRIPTION
## Summary

- Removes `--detach` from `railway up` in `.github/workflows/ci.yml`
- With `--detach`, the CLI exits immediately and the GitHub Deployment status never gets updated — GitHub times it out and shows `cancelled`
- Without it, the CLI waits for the Railway build to finish and reports `success` correctly

Closes #3

## Test plan

- [ ] Merge triggers a deploy job in GitHub Actions
- [ ] The deploy job completes with a green checkmark (not cancelled)
- [ ] GitHub Deployment status shows `success`
- [ ] App is live and running on Railway

🤖 Generated with [Claude Code](https://claude.com/claude-code)