### PR TITLE
Add lurker mode

### DIFF
--- a/client/src/components/ParticipantArea.css
+++ b/client/src/components/ParticipantArea.css
@@ -7,3 +7,11 @@
   flex: 1;
   align-content: center;
 }
+
+.lurker-count {
+  width: 100%;
+  text-align: center;
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #9ca3af);
+  margin: 0;
+}

--- a/client/src/components/ParticipantArea.jsx
+++ b/client/src/components/ParticipantArea.jsx
@@ -1,7 +1,13 @@
 import ParticipantCard from './ParticipantCard.jsx';
 import './ParticipantArea.css';
 
-export default function ParticipantArea({ participants, phase, you, ownerId }) {
+export default function ParticipantArea({
+  participants,
+  phase,
+  you,
+  ownerId,
+  lurkerCount,
+}) {
   const revealed = phase === 'revealed';
 
   return (
@@ -17,6 +23,11 @@ export default function ParticipantArea({ participants, phase, you, ownerId }) {
           isOwner={p.id === ownerId}
         />
       ))}
+      {lurkerCount > 0 && (
+        <p className="lurker-count">
+          {lurkerCount} {lurkerCount === 1 ? 'lurker' : 'lurkers'}
+        </p>
+      )}
     </div>
   );
 }

--- a/client/src/components/RoleSelector.css
+++ b/client/src/components/RoleSelector.css
@@ -54,11 +54,31 @@
 
 .role-btn--lurker {
   width: 100%;
-  color: var(--color-text-muted, #9ca3af);
+  color: var(--color-text);
   border-color: var(--color-border);
 }
 
 .role-btn--lurker:hover {
-  border-color: var(--color-text-muted, #9ca3af);
-  background: rgba(156, 163, 175, 0.1);
+  border-color: var(--color-primary);
+  background: rgba(99, 102, 241, 0.1);
+}
+
+.role-lurker-btn-wrap {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+}
+
+.role-lurker-badge {
+  position: absolute;
+  top: -0.55rem;
+  right: 0.6rem;
+  background: #bbf7d0;
+  color: #166534;
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  pointer-events: none;
+  line-height: 1.4;
 }

--- a/client/src/components/RoleSelector.css
+++ b/client/src/components/RoleSelector.css
@@ -45,3 +45,20 @@
   border-color: var(--color-primary);
   background: rgba(99, 102, 241, 0.1);
 }
+
+.role-lurker {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.role-btn--lurker {
+  width: 100%;
+  color: var(--color-text-muted, #9ca3af);
+  border-color: var(--color-border);
+}
+
+.role-btn--lurker:hover {
+  border-color: var(--color-text-muted, #9ca3af);
+  background: rgba(156, 163, 175, 0.1);
+}

--- a/client/src/components/RoleSelector.jsx
+++ b/client/src/components/RoleSelector.jsx
@@ -19,12 +19,15 @@ export default function RoleSelector({ onSelect }) {
           ))}
         </div>
         <div className="role-lurker">
-          <button
-            className="role-btn role-btn--lurker"
-            onClick={() => onSelect('Lurker')}
-          >
-            Join as Lurker
-          </button>
+          <div className="role-lurker-btn-wrap">
+            <button
+              className="role-btn role-btn--lurker"
+              onClick={() => onSelect('Lurker')}
+            >
+              Join as Lurker
+            </button>
+            <span className="role-lurker-badge">New!</span>
+          </div>
         </div>
       </div>
     </div>

--- a/client/src/components/RoleSelector.jsx
+++ b/client/src/components/RoleSelector.jsx
@@ -18,6 +18,14 @@ export default function RoleSelector({ onSelect }) {
             </button>
           ))}
         </div>
+        <div className="role-lurker">
+          <button
+            className="role-btn role-btn--lurker"
+            onClick={() => onSelect('Lurker')}
+          >
+            Join as Lurker
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/client/src/hooks/useRoom.js
+++ b/client/src/hooks/useRoom.js
@@ -35,7 +35,7 @@ export default function useRoom(roomId) {
   const join = useCallback(
     (role) => {
       socket.connect();
-      socket.emit('room:join', { roomId, role });
+      socket.emit('room:join', { roomId, role, isLurker: role === 'Lurker' });
       setJoined(true);
     },
     [roomId],
@@ -58,12 +58,16 @@ export default function useRoom(roomId) {
   }, []);
 
   const isOwner = roomState?.ownerId === roomState?.you;
+  const isLurker =
+    roomState != null &&
+    !roomState.participants.find((p) => p.id === roomState.you);
 
   return {
     roomState,
     error,
     joined,
     isOwner,
+    isLurker,
     join,
     castVote,
     reveal,

--- a/client/src/pages/RoomPage.jsx
+++ b/client/src/pages/RoomPage.jsx
@@ -17,6 +17,7 @@ export default function RoomPage() {
     error,
     joined,
     isOwner,
+    isLurker,
     join,
     castVote,
     reveal,
@@ -67,16 +68,19 @@ export default function RoomPage() {
         onSet={setTicketUrl}
       />
       {error && <div className="room-error">{error}</div>}
-      <VotingCards
-        selected={myParticipant?.vote}
-        onVote={castVote}
-        disabled={roomState.phase === 'revealed'}
-      />
+      {!isLurker && (
+        <VotingCards
+          selected={myParticipant?.vote}
+          onVote={castVote}
+          disabled={roomState.phase === 'revealed'}
+        />
+      )}
       <ParticipantArea
         participants={roomState.participants}
         phase={roomState.phase}
         you={roomState.you}
         ownerId={roomState.ownerId}
+        lurkerCount={roomState.lurkerCount}
       />
       <ActionBar
         isOwner={isOwner}

--- a/client/src/pages/RoomPage.test.jsx
+++ b/client/src/pages/RoomPage.test.jsx
@@ -69,6 +69,7 @@ describe('RoomPage', () => {
     expect(socket.emit).toHaveBeenCalledWith('room:join', {
       roomId: 'test1234',
       role: 'Dev',
+      isLurker: false,
     });
   });
 });

--- a/server/roomManager.js
+++ b/server/roomManager.js
@@ -27,7 +27,7 @@ export function deleteRoom(roomId) {
   rooms.delete(roomId);
 }
 
-export function addParticipant(roomId, socketId, role) {
+export function addParticipant(roomId, socketId, role, isLurker = false) {
   const room = rooms.get(roomId);
   if (!room) return null;
 
@@ -37,6 +37,7 @@ export function addParticipant(roomId, socketId, role) {
     displayName: '',
     vote: null,
     hasVoted: false,
+    isLurker,
   });
 
   recomputeDisplayNames(room);
@@ -49,14 +50,14 @@ export function removeParticipant(roomId, socketId) {
 
   room.participants.delete(socketId);
 
-  if (room.participants.size === 0) {
+  const nonLurkers = [...room.participants.values()].filter((p) => !p.isLurker);
+  if (nonLurkers.length === 0) {
     rooms.delete(roomId);
     return null;
   }
 
   if (room.ownerId === socketId) {
-    const nextParticipant = room.participants.keys().next().value;
-    room.ownerId = nextParticipant;
+    room.ownerId = nonLurkers[0].id;
   }
 
   recomputeDisplayNames(room);
@@ -70,6 +71,7 @@ export function castVote(roomId, socketId, value) {
 
   const participant = room.participants.get(socketId);
   if (!participant) return null;
+  if (participant.isLurker) return room;
 
   if (participant.vote === value) {
     participant.vote = null;
@@ -126,7 +128,12 @@ export function setTicketUrl(roomId, socketId, url) {
 
 export function sanitizeState(room, forSocketId) {
   const participants = [];
+  let lurkerCount = 0;
   for (const p of room.participants.values()) {
+    if (p.isLurker) {
+      lurkerCount++;
+      continue;
+    }
     participants.push({
       id: p.id,
       role: p.role,
@@ -142,6 +149,7 @@ export function sanitizeState(room, forSocketId) {
     phase: room.phase,
     ticketUrl: room.ticketUrl,
     participants,
+    lurkerCount,
     you: forSocketId,
   };
 }
@@ -149,11 +157,13 @@ export function sanitizeState(room, forSocketId) {
 function recomputeDisplayNames(room) {
   const roleCounts = {};
   for (const p of room.participants.values()) {
+    if (p.isLurker) continue;
     roleCounts[p.role] = (roleCounts[p.role] || 0) + 1;
   }
 
   const roleIndex = {};
   for (const p of room.participants.values()) {
+    if (p.isLurker) continue;
     if (roleCounts[p.role] === 1) {
       p.displayName = p.role;
     } else {

--- a/server/roomManager.test.js
+++ b/server/roomManager.test.js
@@ -324,3 +324,73 @@ describe('resetRoom ticketUrl', () => {
     expect(room.ticketUrl).toBeNull();
   });
 });
+
+describe('lurker mode', () => {
+  it('adds lurker with isLurker flag', () => {
+    const room = createRoom('o1');
+    addParticipant(room.id, 'l1', 'Lurker', true);
+    const p = room.participants.get('l1');
+    expect(p.isLurker).toBe(true);
+    expect(p.role).toBe('Lurker');
+  });
+
+  it('excludes lurkers from sanitizeState participants', () => {
+    const room = createRoom('o1');
+    addParticipant(room.id, 'o1', 'Dev');
+    addParticipant(room.id, 'l1', 'Lurker', true);
+    const state = sanitizeState(room, 'o1');
+    expect(state.participants).toHaveLength(1);
+    expect(state.participants[0].id).toBe('o1');
+  });
+
+  it('includes lurkerCount in sanitizeState', () => {
+    const room = createRoom('o1');
+    addParticipant(room.id, 'o1', 'Dev');
+    addParticipant(room.id, 'l1', 'Lurker', true);
+    addParticipant(room.id, 'l2', 'Lurker', true);
+    const state = sanitizeState(room, 'o1');
+    expect(state.lurkerCount).toBe(2);
+  });
+
+  it('lurkerCount is 0 when no lurkers', () => {
+    const room = createRoom('o1');
+    addParticipant(room.id, 'o1', 'Dev');
+    const state = sanitizeState(room, 'o1');
+    expect(state.lurkerCount).toBe(0);
+  });
+
+  it('castVote is a no-op for lurkers', () => {
+    const room = createRoom('o1');
+    addParticipant(room.id, 'o1', 'Dev');
+    addParticipant(room.id, 'l1', 'Lurker', true);
+    castVote(room.id, 'l1', '5');
+    expect(room.participants.get('l1').vote).toBeNull();
+    expect(room.participants.get('l1').hasVoted).toBe(false);
+  });
+
+  it('ownership does not transfer to a lurker', () => {
+    const room = createRoom('o1');
+    addParticipant(room.id, 'o1', 'Dev');
+    addParticipant(room.id, 'l1', 'Lurker', true);
+    addParticipant(room.id, 's2', 'Product');
+    removeParticipant(room.id, 'o1');
+    expect(room.ownerId).toBe('s2');
+  });
+
+  it('deletes room when last non-lurker leaves', () => {
+    const room = createRoom('o1');
+    addParticipant(room.id, 'o1', 'Dev');
+    addParticipant(room.id, 'l1', 'Lurker', true);
+    const result = removeParticipant(room.id, 'o1');
+    expect(result).toBeNull();
+    expect(roomExists(room.id)).toBe(false);
+  });
+
+  it('lurkers are excluded from display name computation', () => {
+    const room = createRoom('o1');
+    addParticipant(room.id, 's1', 'Dev');
+    addParticipant(room.id, 'l1', 'Lurker', true);
+    // Only one Dev, so displayName should be 'Dev' (not 'Dev 1')
+    expect(room.participants.get('s1').displayName).toBe('Dev');
+  });
+});

--- a/server/socketHandlers.js
+++ b/server/socketHandlers.js
@@ -11,14 +11,14 @@ import {
 export function registerSocketHandlers(io, socket) {
   let currentRoomId = null;
 
-  socket.on('room:join', ({ roomId, role }) => {
-    const room = addParticipant(roomId, socket.id, role);
+  socket.on('room:join', ({ roomId, role, isLurker }) => {
+    const room = addParticipant(roomId, socket.id, role, isLurker);
     if (!room) {
       socket.emit('room:error', { message: 'Room not found' });
       return;
     }
 
-    if (!room.ownerId) {
+    if (!room.ownerId && !isLurker) {
       room.ownerId = socket.id;
     }
 

--- a/server/socketHandlers.test.js
+++ b/server/socketHandlers.test.js
@@ -203,4 +203,71 @@ describe('socket handlers', () => {
 
     c2.close();
   });
+
+  it('lurker joins and receives state with lurkerCount', async () => {
+    const room = createRoom(null);
+    const c1 = connectClient();
+    const lurker = connectClient();
+
+    c1.emit('room:join', { roomId: room.id, role: 'Dev' });
+    await waitForEvent(c1, 'room:state');
+
+    lurker.emit('room:join', {
+      roomId: room.id,
+      role: 'Lurker',
+      isLurker: true,
+    });
+    const state = await waitForEvent(c1, 'room:state');
+
+    expect(state.lurkerCount).toBe(1);
+    expect(state.participants).toHaveLength(1);
+    expect(state.participants[0].id).toBe(c1.id);
+
+    c1.close();
+    lurker.close();
+  });
+
+  it('lurker does not become owner', async () => {
+    const room = createRoom(null);
+    const lurker = connectClient();
+
+    lurker.emit('room:join', {
+      roomId: room.id,
+      role: 'Lurker',
+      isLurker: true,
+    });
+    const state = await waitForEvent(lurker, 'room:state');
+
+    expect(state.ownerId).toBeNull();
+
+    lurker.close();
+  });
+
+  it('lurker vote:cast has no effect', async () => {
+    const room = createRoom(null);
+    const c1 = connectClient();
+    const lurker = connectClient();
+
+    c1.emit('room:join', { roomId: room.id, role: 'Dev' });
+    await waitForEvent(c1, 'room:state');
+
+    lurker.emit('room:join', {
+      roomId: room.id,
+      role: 'Lurker',
+      isLurker: true,
+    });
+    await waitForEvent(lurker, 'room:state');
+
+    const statePromise = waitForEvent(c1, 'room:state');
+    lurker.emit('vote:cast', { roomId: room.id, value: '5' });
+    const state = await statePromise;
+
+    // No participant should have voted
+    for (const p of state.participants) {
+      expect(p.hasVoted).toBe(false);
+    }
+
+    c1.close();
+    lurker.close();
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a **Join as Lurker** option in the role selector (visually separated below the role grid)
- Lurkers receive full real-time room state but have no voting cards and cannot cast votes (blocked both client and server-side)
- Lurkers never become room owner; room closes when the last non-lurker leaves
- A `lurkerCount` is shown in the participant area ("1 lurker" / "N lurkers") when at least one lurker is present — lurkers have no individual cards

## Test plan
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm test` — all 79 tests pass (25 client + 54 server), including 11 new lurker-specific tests
- [x] Open the app, create a room, join as Dev in one tab
- [x] Open a second tab, join the same room as Lurker — confirm no voting cards appear
- [x] First tab should show "1 lurker" in the participant area
- [x] Cast a vote in the first tab — lurker tab sees `hasVoted` indicator update
- [x] Owner reveals votes — lurker tab sees revealed votes
- [x] Owner resets — lurker sees reset state
- [ ] Close the Dev tab (only non-lurker) — lurker should lose connection / room is gone

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)